### PR TITLE
Expose Readline::GEM_VERSION

### DIFF
--- a/ext/readline/readline.c
+++ b/ext/readline/readline.c
@@ -15,6 +15,8 @@
 
 ************************************************/
 
+#define READLINE_VERSION "0.1.5"
+
 #ifdef RUBY_EXTCONF_H
 #include RUBY_EXTCONF_H
 #endif
@@ -2118,6 +2120,8 @@ Init_readline(void)
 #endif
     /* Version string of GNU Readline or libedit. */
     rb_define_const(mReadline, "VERSION", version);
+
+    rb_define_const(mReadline, "GEM_VERSION", rb_str_new_cstr(READLINE_VERSION));
 
     rl_attempted_completion_function = readline_attempted_completion_function;
 #if defined(HAVE_RL_PRE_INPUT_HOOK)

--- a/readline-ext.gemspec
+++ b/readline-ext.gemspec
@@ -1,6 +1,16 @@
+source_version = ["", "ext/readline/"].find do |dir|
+  begin
+    break File.open(File.join(__dir__, "#{dir}readline.c")) {|f|
+      f.gets("\n#define READLINE_VERSION ")
+      f.gets[/\s*"(.+)"/, 1]
+    }
+  rescue Errno::ENOENT
+  end
+end
+
 Gem::Specification.new do |spec|
   spec.name          = "readline-ext"
-  spec.version       = "0.1.5"
+  spec.version       = source_version
   spec.authors       = ["Yukihiro Matsumoto"]
   spec.email         = ["matz@ruby-lang.org"]
 


### PR DESCRIPTION
We already have `Readline::VERSION` for version of GNU Readline. I added `GEM_VERSION` constant.