### PR TITLE
Skip test_interrupt_in_other_thread on arm32-linux

### DIFF
--- a/test/readline/test_readline.rb
+++ b/test/readline/test_readline.rb
@@ -481,6 +481,9 @@ module BasetestReadline
     # likewise with 32-bit userspace on 64-bit kernel
     omit if /\Ax86_64-linux-(?:x32|i[3-6]686)\z/ =~ RUBY_PLATFORM
 
+    # Skip arm32-linux (Travis CI).  See aefc988 in main ruby repo.
+    omit "Skip arm32-linux" if /armv[0-9+][a-z]-linux/ =~ RUBY_PLATFORM
+
     if defined?(TestReadline) && self.class == TestReadline
       use = "use_ext_readline"
     elsif defined?(TestRelineAsReadline) && self.class == TestRelineAsReadline


### PR DESCRIPTION
This is a combination of main Ruby commit
https://github.com/ruby/ruby/commit/aefc98891c42024039f19ef45bdfe93fbc590b7c and my PR correcting the regex https://github.com/ruby/ruby/pull/10819. Upstream Ruby requests that changes to this test go to readline-ext repo before being backported to 3.2 branch.