### PR TITLE
Omit Encoding::CompatibilityError test in Reline

### DIFF
--- a/test/readline/test_readline.rb
+++ b/test/readline/test_readline.rb
@@ -230,6 +230,7 @@ module BasetestReadline
 
   def test_completion_encoding
     omit "Skip Editline" if /EditLine/n.match(Readline::VERSION)
+    omit "Skip Reline" if defined?(Reline) and Readline == Reline
     bug5941 = '[Bug #5941]'
     append_character = Readline.completion_append_character
     Readline.completion_append_character = ""


### PR DESCRIPTION
In Reline, we run these Readline tests. These tests expect Readline to raise an `Encoding::CompatibilityError`, but Reline does not raise this exception. Since I don't think it's necessary for Reline to follow this behavior, we will omit this test in Reline.