### PR TITLE
Remove Reline tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,6 @@ jobs:
     - name: Install dependencies
       run: |
         bundle install
-        gem install reline --pre
     - name: Run test
       run: rake compile test
     - name: Run test with libedit enabled

--- a/test/readline/helper.rb
+++ b/test/readline/helper.rb
@@ -13,22 +13,3 @@ def use_ext_readline # Use ext/readline as Readline
   Object.send(:remove_const, :Readline) if Object.const_defined?(:Readline)
   Object.const_set(:Readline, ReadlineSo)
 end
-
-begin
-  require "reline"
-rescue LoadError
-  Object.class_eval {remove_const :Reline} if defined?(Reline)
-else
-  def use_lib_reline # Use lib/reline as Readline
-    Reline.send(:remove_const, 'IOGate') if Reline.const_defined?('IOGate')
-    Reline.const_set('IOGate', Reline::GeneralIO)
-    Reline.send(:core).config.instance_variable_set(:@test_mode, true)
-    Reline.send(:core).config.reset
-    Object.send(:remove_const, :Readline) if Object.const_defined?(:Readline)
-    Object.const_set(:Readline, Reline)
-  end
-
-  def finish_using_lib_reline
-    Reline.instance_variable_set(:@core, nil)
-  end
-end

--- a/test/readline/test_readline.rb
+++ b/test/readline/test_readline.rb
@@ -486,8 +486,6 @@ module BasetestReadline
 
     if defined?(TestReadline) && self.class == TestReadline
       use = "use_ext_readline"
-    elsif defined?(TestRelineAsReadline) && self.class == TestRelineAsReadline
-      use = "use_lib_reline"
     end
     code = <<-"end;"
       $stdout.sync = true
@@ -825,8 +823,6 @@ module BasetestReadline
     loader = nil
     if defined?(TestReadline) && self.class == TestReadline
       loader = "use_ext_readline"
-    elsif defined?(TestRelineAsReadline) && self.class == TestRelineAsReadline
-      loader = "use_lib_reline"
     end
     if loader
       res, exit_status = Open3.capture2e("#{RUBY} -I#{__dir__} -Ilib -rhelper -e '#{loader}; Readline.readline(%{y or n?})'", stdin_data: "y\n")
@@ -915,26 +911,4 @@ class TestReadline < Test::Unit::TestCase
     use_ext_readline
     super
   end
-end if defined?(ReadlineSo) && ENV["TEST_READLINE_OR_RELINE"] != "Reline"
-
-class TestRelineAsReadline < Test::Unit::TestCase
-  include BasetestReadline
-
-  def setup
-    use_lib_reline
-    super
-  end
-
-  def teardown
-    finish_using_lib_reline
-    super
-  end
-
-  def get_default_internal_encoding
-    if RUBY_PLATFORM =~ /mswin|mingw/
-      Encoding.default_internal || Encoding::UTF_8
-    else
-      Reline::IOGate.encoding
-    end
-  end
-end if defined?(Reline) && ENV["TEST_READLINE_OR_RELINE"] != "Readline"
+end if defined?(ReadlineSo)

--- a/test/readline/test_readline_history.rb
+++ b/test/readline/test_readline_history.rb
@@ -259,8 +259,7 @@ class TestReadlineHistory < Test::Unit::TestCase
     use_ext_readline
     super
   end
-end if defined?(::ReadlineSo) && defined?(::ReadlineSo::HISTORY) &&
-  ENV["TEST_READLINE_OR_RELINE"] != "Reline" &&
+end if defined?(::ReadlineSo) && defined?(::ReadlineSo::HISTORY)
   (
    begin
      ReadlineSo::HISTORY.clear
@@ -268,25 +267,3 @@ end if defined?(::ReadlineSo) && defined?(::ReadlineSo::HISTORY) &&
      false
    end
    )
-
-class TestRelineAsReadlineHistory < Test::Unit::TestCase
-  include BasetestReadlineHistory
-
-  def setup
-    use_lib_reline
-    super
-  end
-
-  def teardown
-    finish_using_lib_reline
-    super
-  end
-
-  def get_default_internal_encoding
-    if RUBY_PLATFORM =~ /mswin|mingw/
-      Encoding.default_internal || Encoding::UTF_8
-    else
-      Reline::IOGate.encoding
-    end
-  end
-end if defined?(Reline) && ENV["TEST_READLINE_OR_RELINE"] != "Readline"


### PR DESCRIPTION
No longer needed as Reline runs tests for readline-ext.

https://github.com/ruby/reline/blob/5a8da85f2b10a5e46050f628dd04f485869ab3a3/.github/workflows/reline.yml#L50-L79